### PR TITLE
fix cronjob condition successcriteriamet

### DIFF
--- a/src/modules/kubernetes/get.py
+++ b/src/modules/kubernetes/get.py
@@ -359,6 +359,9 @@ def getCronjob(
         if type(job_latest) is dict:
             continue
 
+        # quick patch for 'SuccessCriteriaMet' in job condition
+        [job_latest.status.conditions.pop(i) for i, _ in enumerate(job_latest.status.conditions) if _.type == 'SuccessCriteriaMet'][0]
+
         if job_latest.status.conditions[0].type == "Complete":
             cronjob_status = "0"
         else:


### PR DESCRIPTION
This pull request includes a small change to the `getCronjob` function in `src/modules/kubernetes/get.py`. The change introduces a patch to remove any job condition with the type `SuccessCriteriaMet` from the `job_latest.status.conditions` list before further processing.